### PR TITLE
Port to Minecraft 1.21.11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import net.fabricmc.loom.api.LoomGradleExtensionAPI
 
 plugins {
-    id("dev.architectury.loom") version "1.11-SNAPSHOT" apply false
+    id("dev.architectury.loom") version "1.13-SNAPSHOT" apply false
     id("architectury-plugin") version "3.4-SNAPSHOT"
     id("com.gradleup.shadow") version "8.3.6" apply false
     id("me.modmuss50.mod-publish-plugin") version "1.1.0" apply false

--- a/common/src/main/java/dev/micalobia/fullslabs/FullSlabs.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/FullSlabs.java
@@ -6,7 +6,7 @@ import dev.micalobia.fullslabs.config.Config;
 import dev.micalobia.fullslabs.config.Controls;
 import dev.micalobia.fullslabs.loot.VerticalLootTable;
 import eu.midnightdust.lib.config.MidnightConfig;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SlabBlock;
 import org.apache.logging.log4j.LogManager;
@@ -15,9 +15,10 @@ import org.apache.logging.log4j.Logger;
 public final class FullSlabs {
     public static final String MODID = "fullslabs";
     public static final Logger LOGGER = LogManager.getLogger(MODID);
-    public static final SlabBlock DEFAULT = (SlabBlock) Blocks.STONE_SLAB;
+    public static SlabBlock DEFAULT;
 
     public static void init() {
+        DEFAULT = (SlabBlock) Blocks.STONE_SLAB;
         MidnightConfig.init(MODID, Config.class);
         FullSlabsCompat.init();
         SlabRegistry.init();
@@ -25,11 +26,11 @@ public final class FullSlabs {
         Controls.serverInit();
     }
 
-    public static ResourceLocation id(String path) {
-        return ResourceLocation.fromNamespaceAndPath(FullSlabs.MODID, path);
+    public static Identifier id(String path) {
+        return Identifier.fromNamespaceAndPath(FullSlabs.MODID, path);
     }
 
-    public static String verticalPath(ResourceLocation parent) {
+    public static String verticalPath(Identifier parent) {
         return "vertical/" + parent.toString().replace(':', '/');
     }
 }

--- a/common/src/main/java/dev/micalobia/fullslabs/SlabRegistry.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/SlabRegistry.java
@@ -16,7 +16,7 @@ import dev.micalobia.fullslabs.util.Utility;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.HoneycombItem;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SlabBlock;
@@ -59,7 +59,7 @@ public class SlabRegistry {
     }
 
     private static <T extends Block> RegistrySupplier<T> registerBlock(String id, Function<Properties, T> func, Supplier<Properties> settings) {
-        return BLOCKS.register(id, () -> func.apply(settings.get().setId(generateKey(id))));
+        return BLOCKS.register(id, () -> func.apply(settings.get().setId(generateKey((String) id))));
     }
 
     public static void init() {
@@ -87,7 +87,7 @@ public class SlabRegistry {
         return generateKey(FullSlabs.id(path));
     }
 
-    private static ResourceKey<Block> generateKey(ResourceLocation id) {
+    private static ResourceKey<Block> generateKey(Identifier id) {
         return ResourceKey.create(Registries.BLOCK, id);
     }
 
@@ -157,7 +157,7 @@ public class SlabRegistry {
     }
 
     @ApiStatus.Internal
-    public static void tryRegisterVertical(ResourceLocation id, Block block) {
+    public static void tryRegisterVertical(Identifier id, Block block) {
         if (!(block instanceof SlabBlock slab)) return;
         var factory = MAPPING.get(slab.getClass());
         if (factory == null) {

--- a/common/src/main/java/dev/micalobia/fullslabs/block/MixedSlabBlock.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/block/MixedSlabBlock.java
@@ -5,7 +5,6 @@ import dev.micalobia.fullslabs.block.entity.MixedSlabBlockEntity;
 import dev.micalobia.fullslabs.handlers.MixedHandlers;
 import dev.micalobia.fullslabs.util.MixedType;
 import dev.micalobia.fullslabs.util.Utility;
-import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -36,7 +35,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.function.ToIntFunction;
 
-@MethodsReturnNonnullByDefault
 public final class MixedSlabBlock extends Block implements EntityBlock, SlabLike {
     public static final EnumProperty<MixedType> TYPE = EnumProperty.create("type", MixedType.class);
     public static final IntegerProperty LEVEL = BlockStateProperties.LEVEL;

--- a/common/src/main/java/dev/micalobia/fullslabs/block/OxidizableVerticalSlabBlock.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/block/OxidizableVerticalSlabBlock.java
@@ -1,6 +1,5 @@
 package dev.micalobia.fullslabs.block;
 
-import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
@@ -8,7 +7,6 @@ import net.minecraft.world.level.block.WeatheringCopper;
 import net.minecraft.world.level.block.WeatheringCopperSlabBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
-@MethodsReturnNonnullByDefault
 public class OxidizableVerticalSlabBlock extends VerticalSlabBlock implements WeatheringCopper {
     private final WeatherState oxidationLevel;
 

--- a/common/src/main/java/dev/micalobia/fullslabs/block/VerticalSlabBlock.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/block/VerticalSlabBlock.java
@@ -2,7 +2,6 @@ package dev.micalobia.fullslabs.block;
 
 import dev.micalobia.fullslabs.handlers.MixedHandlers;
 import dev.micalobia.fullslabs.util.MixedType;
-import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.tags.FluidTags;
@@ -40,7 +39,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-@MethodsReturnNonnullByDefault
 public class VerticalSlabBlock extends Block implements SimpleWaterloggedBlock, SlabLike {
     private static final Map<SlabBlock, VerticalSlabBlock> MAP = new HashMap<>();
     public static final EnumProperty<Direction> DIRECTION = BlockStateProperties.HORIZONTAL_FACING;

--- a/common/src/main/java/dev/micalobia/fullslabs/block/entity/MixedSlabBlockEntity.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/block/entity/MixedSlabBlockEntity.java
@@ -5,7 +5,6 @@ import dev.micalobia.fullslabs.SlabRegistry;
 import dev.micalobia.fullslabs.block.MixedSlabBlock;
 import dev.micalobia.fullslabs.block.VerticalSlabBlock;
 import dev.micalobia.fullslabs.handlers.MixedHandlers;
-import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -13,7 +12,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -29,7 +28,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
-@MethodsReturnNonnullByDefault
 public class MixedSlabBlockEntity extends BlockEntity {
     // I'd like to find a better way to do what this does
     private static Tuple<SlabBlock, SlabBlock> CACHE = new Tuple<>((SlabBlock) Blocks.STONE_SLAB, (SlabBlock) Blocks.STONE_SLAB);
@@ -149,13 +147,13 @@ public class MixedSlabBlockEntity extends BlockEntity {
     protected void loadAdditional(ValueInput input) {
         var towardsStr = input.getStringOr("towards_id", "minecraft:stone_slab");
         var awayStr = input.getStringOr("away_id", "minecraft:stone_slab");
-        if (BuiltInRegistries.BLOCK.getValue(ResourceLocation.parse(towardsStr)) instanceof SlabBlock slab)
+        if (BuiltInRegistries.BLOCK.getValue(Identifier.parse(towardsStr)) instanceof SlabBlock slab)
             this.towards = slab;
         else {
             FullSlabs.LOGGER.warn("missing \"{}\": replacing with \"minecraft:stone_slab\"", towardsStr);
             this.towards = (SlabBlock) Blocks.STONE_SLAB;
         }
-        if (BuiltInRegistries.BLOCK.getValue(ResourceLocation.parse(awayStr)) instanceof SlabBlock slab)
+        if (BuiltInRegistries.BLOCK.getValue(Identifier.parse(awayStr)) instanceof SlabBlock slab)
             this.away = slab;
         else {
             FullSlabs.LOGGER.warn("missing \"{}\": replacing with \"minecraft:stone_slab\"", awayStr);

--- a/common/src/main/java/dev/micalobia/fullslabs/client/BlockFaceOverlay.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/client/BlockFaceOverlay.java
@@ -10,7 +10,8 @@ import dev.micalobia.fullslabs.util.Constants;
 import dev.micalobia.fullslabs.util.SlabPlacement;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.state.LevelRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -30,8 +31,7 @@ public final class BlockFaceOverlay {
     private static final double EPSILON = 1e-4d;
 
 
-    private static final RenderType QUAD_LAYER = RenderType.debugQuads();
-    private static final RenderType LINE_LAYER = RenderType.debugLineStrip(2f);
+    private static final RenderType QUAD_LAYER = RenderTypes.debugQuads();
 
     private BlockFaceOverlay() {
     }
@@ -65,7 +65,6 @@ public final class BlockFaceOverlay {
         var nHit = hit.subtract(pos.getX(), pos.getY(), pos.getZ());
         var map = new LinkedHashMap<RenderType, ByteBufferBuilder>();
         map.put(QUAD_LAYER, new ByteBufferBuilder(1024));
-        map.put(LINE_LAYER, new ByteBufferBuilder(512));
         var immediate = MultiBufferSource.immediateWithBuffers(map, new ByteBufferBuilder(1024));
         var stack = new PoseStack();
         stack.pushPose();
@@ -94,7 +93,6 @@ public final class BlockFaceOverlay {
             emitFill(entry, immediate, frame, poly);
         });
         immediate.endBatch();
-        drawLines(entry, immediate, frame, edgeMap);
         stack.popPose();
     }
 
@@ -239,18 +237,6 @@ public final class BlockFaceOverlay {
     }
 
     private static void drawLines(PoseStack.Pose entry, MultiBufferSource.BufferSource provider, FaceFrame frame, Map<EdgeKey, UVSeg> edgeMap) {
-        var n = frame.n();
-        var offset = n.scale(EPSILON);
-        var chains = buildChains(edgeMap);
-        for (var chain : chains) {
-            chain = mergeColinear(chain);
-            var vc = provider.getBuffer(LINE_LAYER);
-            for (var v : chain) {
-                var p = uvToWorld(v.x + 0.5d, v.y + 0.5d, frame).add(offset);
-                vc.addVertex(entry, (float) p.x, (float) p.y, (float) p.z).setColor(Config.edgeColor()).setNormal(entry, (float) n.x, (float) n.y, (float) n.z);
-            }
-            provider.endBatch();
-        }
     }
 
     private static List<Vec2> mergeColinear(List<Vec2> in) {

--- a/common/src/main/java/dev/micalobia/fullslabs/client/models/MixedSlabModel.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/client/models/MixedSlabModel.java
@@ -1,12 +1,10 @@
 package dev.micalobia.fullslabs.client.models;
 
 import dev.architectury.injectables.annotations.ExpectPlatform;
-import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.client.renderer.block.model.BlockStateModel;
 import net.minecraft.client.resources.model.ModelBaker;
 import net.minecraft.world.level.block.state.BlockState;
 
-@MethodsReturnNonnullByDefault
 public final class MixedSlabModel implements BlockStateModel.UnbakedRoot {
     public static final MixedSlabModel INSTANCE = new MixedSlabModel();
 

--- a/common/src/main/java/dev/micalobia/fullslabs/client/models/VerticalSlabModel.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/client/models/VerticalSlabModel.java
@@ -7,7 +7,6 @@ import dev.micalobia.fullslabs.block.VerticalSlabBlock.VerticalType;
 import dev.micalobia.fullslabs.config.Config;
 import dev.micalobia.fullslabs.mixin.client.ModelBakerImplAccessor;
 import dev.micalobia.fullslabs.mixin.client.ModelBakeryAccessor;
-import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.client.renderer.block.model.*;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -16,7 +15,7 @@ import net.minecraft.client.resources.model.Material;
 import net.minecraft.client.resources.model.ModelBaker;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -27,13 +26,12 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Optional;
 
-@MethodsReturnNonnullByDefault
 public class VerticalSlabModel implements BlockStateModel.UnbakedRoot {
     @SuppressWarnings("deprecation")
-    private static final ResourceLocation ATLAS = TextureAtlas.LOCATION_BLOCKS;
+    private static final Identifier ATLAS = TextureAtlas.LOCATION_BLOCKS;
     public static final VerticalSlabModel INSTANCE = new VerticalSlabModel();
 
-    public static final List<ResourceLocation> TEMPLATES = templates();
+    public static final List<Identifier> TEMPLATES = templates();
 
     private VerticalSlabModel() {
     }
@@ -43,7 +41,7 @@ public class VerticalSlabModel implements BlockStateModel.UnbakedRoot {
         return slab;
     }
 
-    public static ResourceLocation templateId(BlockState state) {
+    public static Identifier templateId(BlockState state) {
         var slab = verifyVertical(state.getBlock());
         var facing = state.getValue(VerticalSlabBlock.DIRECTION);
         var type = state.getValue(VerticalSlabBlock.TYPE);
@@ -65,7 +63,7 @@ public class VerticalSlabModel implements BlockStateModel.UnbakedRoot {
         };
     }
 
-    public static ResourceLocation makeModelId(BlockState state) {
+    public static Identifier makeModelId(BlockState state) {
         var slab = verifyVertical(state.getBlock());
         return FullSlabs.id("block/%s/%s_%s".formatted(BuiltInRegistries.BLOCK.getKey(slab).getPath(), state.getValue(VerticalSlabBlock.DIRECTION).getSerializedName(), state.getValue(VerticalSlabBlock.TYPE).getSerializedName()));
     }
@@ -88,7 +86,7 @@ public class VerticalSlabModel implements BlockStateModel.UnbakedRoot {
         var mapped = mapped(parentId.toString(), textures);
         var template = baker.getModel(templateId);
         var geometry = template.getTopGeometry();
-        var quads = geometry.bake(mapped, baker, BlockModelRotation.X0_Y0, template);
+        var quads = geometry.bake(mapped, baker, BlockModelRotation.IDENTITY, template);
         var part = new SimpleModelWrapper(quads, useAO, particle);
         return new SingleVariant(part);
     }
@@ -106,8 +104,8 @@ public class VerticalSlabModel implements BlockStateModel.UnbakedRoot {
         TEMPLATES.forEach(resolver::markDependency);
     }
 
-    private static List<ResourceLocation> templates() {
-        var builder = new ImmutableList.Builder<ResourceLocation>();
+    private static List<Identifier> templates() {
+        var builder = new ImmutableList.Builder<Identifier>();
         Direction.Plane.HORIZONTAL.forEach(direction -> {
             var str = direction.getSerializedName();
             builder.add(FullSlabs.id("block/vertical/tilted/%s_towards".formatted(str)));

--- a/common/src/main/java/dev/micalobia/fullslabs/config/Config.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/config/Config.java
@@ -4,7 +4,7 @@ package dev.micalobia.fullslabs.config;
 import com.google.common.collect.Lists;
 import eu.midnightdust.lib.config.MidnightConfig;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.Block;
 
 import java.util.List;
@@ -14,26 +14,26 @@ public class Config extends MidnightConfig {
     public static final String GENERAL = "general";
     public static final String OVERLAY = "overlay";
     @Entry(category = GENERAL, idMode = 1, width = 1000)
-    public static List<ResourceLocation> tiltedSlabs = Lists.newArrayList(
-            ResourceLocation.withDefaultNamespace("smooth_stone_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "white_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "orange_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "magenta_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "light_blue_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "yellow_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "lime_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "pink_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "gray_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "light_gray_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "cyan_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "purple_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "blue_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "brown_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "green_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "red_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "black_stained_glass_slab"),
-            ResourceLocation.fromNamespaceAndPath("mo_glass", "tinted_glass_slab")
+    public static List<Identifier> tiltedSlabs = Lists.newArrayList(
+            Identifier.withDefaultNamespace("smooth_stone_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "white_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "orange_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "magenta_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "light_blue_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "yellow_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "lime_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "pink_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "gray_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "light_gray_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "cyan_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "purple_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "blue_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "brown_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "green_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "red_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "black_stained_glass_slab"),
+            Identifier.fromNamespaceAndPath("mo_glass", "tinted_glass_slab")
     );
     @Entry(category = OVERLAY, min = 0, max = 255, isSlider = true)
     public static int edgeOpacity = 255;

--- a/common/src/main/java/dev/micalobia/fullslabs/handlers/MixedHandlers.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/handlers/MixedHandlers.java
@@ -4,7 +4,7 @@ import dev.micalobia.fullslabs.FullSlabs;
 import dev.micalobia.fullslabs.block.SlabLike;
 import dev.micalobia.fullslabs.block.VerticalSlabBlock;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SlabBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Optional;
 
 public final class MixedHandlers {
-    private static final HashMap<ResourceLocation, MixedHandlerFactory> ID_HANDLERS = new HashMap<>();
+    private static final HashMap<Identifier, MixedHandlerFactory> ID_HANDLERS = new HashMap<>();
     private static final HashMap<SlabBlock, MixedHandlerFactory> BLOCK_HANDLERS = new HashMap<>();
     private static final HashMap<Class<? extends SlabBlock>, MixedHandlerFactory> CLASS_HANDLERS = new HashMap<>();
     private static final HashMap<SlabBlock, MixedHandler> HANDLERS = new HashMap<>();
@@ -59,11 +59,11 @@ public final class MixedHandlers {
 
     public static MixedHandler getOrThrow(BlockState state) {return getOrThrow(state.getBlock());}
 
-    public static void register(ResourceLocation identifier, MixedHandler handler) {
+    public static void register(Identifier identifier, MixedHandler handler) {
         register(identifier, slab -> handler);
     }
 
-    public static void register(ResourceLocation identifier, MixedHandlerFactory factory) {
+    public static void register(Identifier identifier, MixedHandlerFactory factory) {
         BuiltInRegistries.BLOCK.getOptional(identifier).ifPresentOrElse(
                 block -> register(block, factory),
                 () -> ID_HANDLERS.put(identifier, factory)
@@ -88,7 +88,7 @@ public final class MixedHandlers {
         CLASS_HANDLERS.put(klass, factory);
     }
 
-    private static void resolve(ResourceLocation id) {
+    private static void resolve(Identifier id) {
         BuiltInRegistries.BLOCK.getOptional(id).ifPresent(block -> resolve(block, id));
     }
 
@@ -96,7 +96,7 @@ public final class MixedHandlers {
         resolve(block, BuiltInRegistries.BLOCK.getKey(block));
     }
 
-    private static void resolve(Block block, ResourceLocation id) {
+    private static void resolve(Block block, Identifier id) {
         if (ID_HANDLERS.containsKey(id))
             register(block, ID_HANDLERS.remove(id));
     }

--- a/common/src/main/java/dev/micalobia/fullslabs/loot/VerticalLootTable.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/loot/VerticalLootTable.java
@@ -3,10 +3,10 @@ package dev.micalobia.fullslabs.loot;
 import dev.architectury.event.events.common.LootEvent;
 import dev.micalobia.fullslabs.FullSlabs;
 import dev.micalobia.fullslabs.block.VerticalSlabBlock;
-import net.minecraft.advancements.critereon.StatePropertiesPredicate;
+import net.minecraft.advancements.criterion.StatePropertiesPredicate;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.SlabBlock;
 import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.LootTable;
@@ -39,7 +39,7 @@ public class VerticalLootTable implements LootEvent.ModifyLootTable {
                             slabs.size(),
                             slabs.stream()
                                     .map(BuiltInRegistries.BLOCK::getKey)
-                                    .map(ResourceLocation::toString)
+                                    .map(Identifier::toString)
                                     .collect(Collectors.joining(", ")));
                 }
             });

--- a/common/src/main/java/dev/micalobia/fullslabs/mixin/TagLoaderMixin.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/mixin/TagLoaderMixin.java
@@ -5,7 +5,7 @@ import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import dev.micalobia.fullslabs.block.VerticalSlabBlock;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.tags.TagLoader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SlabBlock;
@@ -24,7 +24,7 @@ public class TagLoaderMixin {
     private String directory;
 
     @ModifyReturnValue(method = "build", at = @At("RETURN"))
-    private Map<ResourceLocation, List<Holder.Reference<Block>>> injectVerticalSlabTags(Map<ResourceLocation, List<Holder.Reference<Block>>> original) {
+    private Map<Identifier, List<Holder.Reference<Block>>> injectVerticalSlabTags(Map<Identifier, List<Holder.Reference<Block>>> original) {
         if (!"tags/block".equals(this.directory)) return original;
         original.keySet().stream().filter(id -> id.getPath().contains("mineable/")).forEach(id -> {
             var list = original.get(id);

--- a/common/src/main/java/dev/micalobia/fullslabs/util/MixedType.java
+++ b/common/src/main/java/dev/micalobia/fullslabs/util/MixedType.java
@@ -2,7 +2,6 @@ package dev.micalobia.fullslabs.util;
 
 import com.google.common.collect.ImmutableList;
 import dev.micalobia.fullslabs.block.VerticalSlabBlock;
-import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.StringRepresentable;
@@ -15,7 +14,6 @@ import net.minecraft.world.phys.Vec3;
 import java.util.List;
 import java.util.Objects;
 
-@MethodsReturnNonnullByDefault
 public enum MixedType implements StringRepresentable {
     NORTH("north", Direction.NORTH),
     SOUTH("south", Direction.SOUTH),

--- a/fabric/src/main/java/dev/micalobia/fullslabs/fabric/compat/mo_glass/StainedGlassVerticalSlabBlock.java
+++ b/fabric/src/main/java/dev/micalobia/fullslabs/fabric/compat/mo_glass/StainedGlassVerticalSlabBlock.java
@@ -1,6 +1,5 @@
 package dev.micalobia.fullslabs.fabric.compat.mo_glass;
 
-import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.block.BeaconBeamBlock;
@@ -9,7 +8,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.wurstclient.glass.StainedGlassSlabBlock;
 import net.wurstclient.glass.StainedGlassStairsBlock;
 
-@MethodsReturnNonnullByDefault
 public class StainedGlassVerticalSlabBlock extends GlassVerticalSlabBlock implements BeaconBeamBlock {
     private final DyeColor color;
 

--- a/fabric/src/main/java/dev/micalobia/fullslabs/fabric/compat/slabsandstairs/IceVerticalSlabBlock.java
+++ b/fabric/src/main/java/dev/micalobia/fullslabs/fabric/compat/slabsandstairs/IceVerticalSlabBlock.java
@@ -28,7 +28,7 @@ public class IceVerticalSlabBlock extends VerticalSlabBlock {
     public void playerDestroy(Level level, Player player, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, ItemStack tool) {
         super.playerDestroy(level, player, pos, state, blockEntity, tool);
         if (!EnchantmentHelper.hasTag(tool, EnchantmentTags.PREVENTS_ICE_MELTING)) {
-            if (level.dimensionType().ultraWarm()) {
+            if (level.dimension().equals(Level.NETHER)) {
                 level.removeBlock(pos, false);
                 return;
             }
@@ -48,7 +48,7 @@ public class IceVerticalSlabBlock extends VerticalSlabBlock {
     }
 
     protected void melt(Level world, BlockPos pos) {
-        if (world.dimensionType().ultraWarm()) world.removeBlock(pos, false);
+        if (world.dimension().equals(Level.NETHER)) world.removeBlock(pos, false);
         else {
             world.setBlockAndUpdate(pos, IceBlock.meltsInto());
             world.neighborChanged(pos, IceBlock.meltsInto().getBlock(), null);

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,17 +7,17 @@ maven_group=dev.micalobia
 archives_name=fullslabs
 enabled_platforms=fabric,neoforge
 # Minecraft properties
-minecraft_version=1.21.10
-minecraft_versions=1.21.9,1.21.10
-parchment_version=2025.10.12
+minecraft_version=1.21.11
+minecraft_versions=1.21.10,1.21.11
+parchment_version=2025.12.20
 # Dependencies
-architectury_api_version=18.0.6
-fabric_loader_version=0.17.3
-fabric_api_version=0.134.1+1.21.10
-neoforge_version=21.10.34-beta
+architectury_api_version=19.0.1
+fabric_loader_version=0.18.4
+fabric_api_version=0.141.3+1.21.11
+neoforge_version=21.11.38-beta
 yarn_mappings_patch_neoforge_version=1.21+build.4
-modmenu_version=16.0.0-rc.1
-midnightlib_version=1.8.3+1.21.9
+modmenu_version=17.0.0-beta.2
+midnightlib_version=1.9.2+1.21.11
 # Compat
 blockus_version=2.14.0+1.21.10
 mo_glass_version=1.11-MC1.21.10


### PR DESCRIPTION
Ports the mod to Minecraft 1.21.11.

## Changes

- Bump all dependency versions for 1.21.11 (Fabric API 0.141.3, NeoForge 21.11.38-beta, Architectury 19.0.1, MidnightLib 1.9.2, ModMenu 17.0.0-beta.2, Parchment 2025.12.20, Fabric Loader 0.18.4)
- Update Architectury Loom to 1.13-SNAPSHOT
- ResourceLocation renamed to Identifier (net.minecraft.resources) - updated all imports and usages
- Fix StatePropertiesPredicate import: critereon to criterion (Mojang fixed the typo)
- RenderType moved to net.minecraft.client.renderer.rendertype; removed line overlay rendering as debugLineStrip no longer exists and lines() topology caused visual artifacts
- BlockModelRotation.X0_Y0 replaced with BlockModelRotation.IDENTITY
- Remove @MethodsReturnNonnullByDefault (removed from net.minecraft in 1.21.11)
- DimensionType.ultraWarm() removed - replaced with Level.NETHER dimension key check in IceVerticalSlabBlock
- Fix early-bootstrap crash: defer FullSlabs.DEFAULT (Blocks.STONE_SLAB) from static field to init() to avoid registry access before Minecraft bootstrap completes
- Fix ambiguous generateKey(String) overload in SlabRegistry